### PR TITLE
Add configurable path for annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,16 @@
           "type": "boolean",
           "default": true,
           "annotation": "Automatically save annotations when edited"
+        },
+        "codebaseNotes.path": {
+          "type": "string",
+          "default": ".vscode",
+          "description": "Where to save the notes, relative to the workspace root."
+        },
+        "codebaseNotes.filename": {
+          "type": "string",
+          "default": ".codebasenotes-annotations.json",
+          "description": "The name of the `*.json` file with the annotations."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,9 +19,9 @@ export function activate(context: vscode.ExtensionContext) {
     const annotationEditorProvider = new AnnotationEditorProvider(context.extensionUri, workspaceRoot);
     const projectTreeProvider = new ProjectTreeProvider(workspaceRoot, annotationEditorProvider);
 
-    const treeView = vscode.window.createTreeView('projectTree', { 
-        treeDataProvider: projectTreeProvider, 
-        showCollapseAll: true 
+    const treeView = vscode.window.createTreeView('projectTree', {
+        treeDataProvider: projectTreeProvider,
+        showCollapseAll: true
     });
 
     // Listen for when the view becomes visible
@@ -48,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 function registerCommands(
-    projectTreeProvider: ProjectTreeProvider, 
+    projectTreeProvider: ProjectTreeProvider,
     annotationEditorProvider: AnnotationEditorProvider,
     workspaceRoot: string,
     treeView: vscode.TreeView<string>
@@ -83,8 +83,8 @@ function registerCommands(
 }
 
 function setupEventListeners(
-    context: vscode.ExtensionContext, 
-    projectTreeProvider: ProjectTreeProvider, 
+    context: vscode.ExtensionContext,
+    projectTreeProvider: ProjectTreeProvider,
     treeView: vscode.TreeView<string>,
     workspaceRoot: string,
     annotationEditorProvider: AnnotationEditorProvider
@@ -135,8 +135,8 @@ function setupEventListeners(
 }
 
 async function revealFileInTree(
-    uri: vscode.Uri, 
-    treeView: vscode.TreeView<string>, 
+    uri: vscode.Uri,
+    treeView: vscode.TreeView<string>,
     workspaceRoot: string,
     projectTreeProvider: ProjectTreeProvider
 ) {
@@ -152,7 +152,7 @@ async function revealFileInTree(
                 // For files, expand parent directories and reveal
                 const relativePath = path.relative(workspaceRoot, uri.fsPath);
                 const pathParts = relativePath.split(path.sep);
-                
+
                 // Expand only the parent directories
                 for (let i = 0; i < pathParts.length - 1; i++) {
                     const partialPath = path.join(workspaceRoot, ...pathParts.slice(0, i + 1));


### PR DESCRIPTION
This PR introduces configurability to the location and filename of the annotations file generated by Codebase Notes.

### 🔧 Changes

* Added new user settings:

  * `codebaseNotes.path`: defines the directory where the annotations file will be stored.
  * `codebaseNotes.filename`: allows users to customize the name of the annotations file.
* Changed the default behavior to store the annotations file in the `.vscode` folder instead of the workspace root.

### ✅ Motivation

Storing `.codebasenotes-annotations.json` directly in the workspace root can clutter the project. Moving it to `.vscode` by default aligns better with other editor metadata and provides a cleaner structure. Moreover, making the path and filename configurable gives teams more flexibility to adopt their own conventions.

### 💡 Notes

These new settings can also be configured via the workspace's `.vscode/settings.json` file, which means they can be local to the project and version-controlled if desired.